### PR TITLE
Windows compatibility

### DIFF
--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -236,7 +236,13 @@ class HierarchicalPath extends AbstractHierarchicalComponent implements Interfac
      */
     public function getDirname()
     {
-        return str_replace("\0", '\\', pathinfo(str_replace('\\', "\0", $this), PATHINFO_DIRNAME));
+        $parentDirectory = str_replace("\\", "\0", $this);
+        $parentDirectory = dirname($parentDirectory);
+        // The `dirname` call exchanges a single slash with a backslash on Windows platform.
+        $parentDirectory = str_replace("\\", static::$separator, $parentDirectory);
+        $parentDirectory = str_replace("\0", "\\", $parentDirectory);
+
+        return $parentDirectory;
     }
 
     /**

--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -236,11 +236,11 @@ class HierarchicalPath extends AbstractHierarchicalComponent implements Interfac
      */
     public function getDirname()
     {
-        $parentDirectory = str_replace("\\", "\0", $this);
+        $parentDirectory = str_replace('\\', "\0", $this);
         $parentDirectory = dirname($parentDirectory);
         // The `dirname` call exchanges a single slash with a backslash on Windows platform.
-        $parentDirectory = str_replace("\\", static::$separator, $parentDirectory);
-        $parentDirectory = str_replace("\0", "\\", $parentDirectory);
+        $parentDirectory = str_replace('\\', static::$separator, $parentDirectory);
+        $parentDirectory = str_replace("\0", '\\', $parentDirectory);
 
         return $parentDirectory;
     }

--- a/test/Schemes/DataTest.php
+++ b/test/Schemes/DataTest.php
@@ -259,6 +259,9 @@ class DataTest extends PHPUnit_Framework_TestCase
         $res = $uri->save($newFilePath);
         $this->assertInstanceOf('\SplFileObject', $res);
         $this->assertTrue($uri->sameValueAs(DataUri::createFromPath($newFilePath)));
+
+        // Ensure file handle of \SplFileObject gets closed.
+        $res = null;
         unlink($newFilePath);
     }
 
@@ -271,6 +274,9 @@ class DataTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($uri->sameValueAs(DataUri::createFromPath($newFilePath)));
         $data = file_get_contents($newFilePath);
         $this->assertSame(base64_encode($data), $uri->getData());
+
+        // Ensure file handle of \SplFileObject gets closed.
+        $res = null;
         unlink($newFilePath);
     }
 


### PR DESCRIPTION
All tests are successful on Windows 7 x64 with PHP 5.6.11 x64 NTS VC11 after these changes.
