### PR TITLE
Fix: Namespace should be League\Uri\Test

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -28,6 +28,7 @@ return Symfony\CS\Config\Config::create()
         'ternary_spaces',
         'operators_spaces',
         'new_with_braces',
+        '-psr0',
     ])
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()

--- a/test/Components/FragmentTest.php
+++ b/test/Components/FragmentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Fragment;

--- a/test/Components/HierarchicalPathTest.php
+++ b/test/Components/HierarchicalPathTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use ArrayIterator;
 use InvalidArgumentException;

--- a/test/Components/HostTest.php
+++ b/test/Components/HostTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use ArrayIterator;
 use InvalidArgumentException;

--- a/test/Components/PassTest.php
+++ b/test/Components/PassTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Pass;

--- a/test/Components/PathTest.php
+++ b/test/Components/PathTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Path;

--- a/test/Components/PortTest.php
+++ b/test/Components/PortTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use League\Uri\Components\Port;
 use PHPUnit_Framework_TestCase;

--- a/test/Components/QueryTest.php
+++ b/test/Components/QueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use ArrayIterator;
 use InvalidArgumentException;

--- a/test/Components/SchemeTest.php
+++ b/test/Components/SchemeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use League\Uri\Components\Scheme;
 use PHPUnit_Framework_TestCase;

--- a/test/Components/UserInfoTest.php
+++ b/test/Components/UserInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use League\Uri\Components\UserInfo;
 use PHPUnit_Framework_TestCase;

--- a/test/Components/UserTest.php
+++ b/test/Components/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Components;
+namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\User;

--- a/test/FormatterTest.php
+++ b/test/FormatterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test;
+namespace League\Uri\Test;
 
 use InvalidArgumentException;
 use League\Uri;

--- a/test/QueryParserTest.php
+++ b/test/QueryParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test;
+namespace League\Uri\Test;
 
 use League\Uri\QueryParser;
 use PHPUnit_Framework_TestCase;

--- a/test/Schemes/DataTest.php
+++ b/test/Schemes/DataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes;
+namespace League\Uri\Test\Schemes;
 
 use InvalidArgumentException;
 use League\Uri;

--- a/test/Schemes/FtpTest.php
+++ b/test/Schemes/FtpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes;
+namespace League\Uri\Test\Schemes;
 
 use InvalidArgumentException;
 use League\Uri\Schemes\Ftp as FtpUri;

--- a/test/Schemes/Generic/HierarchicalUriModifierTest.php
+++ b/test/Schemes/Generic/HierarchicalUriModifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes\Generic;
+namespace League\Uri\Test\Schemes\Generic;
 
 use League\Uri\Interfaces;
 use League\Uri\Schemes\Http as HttpUri;

--- a/test/Schemes/Generic/HierarchicalUriTest.php
+++ b/test/Schemes/Generic/HierarchicalUriTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes\Generic;
+namespace League\Uri\Test\Schemes\Generic;
 
 use InvalidArgumentException;
 use League\Uri\Components;

--- a/test/Schemes/HttpTest.php
+++ b/test/Schemes/HttpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes;
+namespace League\Uri\Test\Schemes;
 
 use InvalidArgumentException;
 use League\Uri\Schemes\Data as DataUri;

--- a/test/Schemes/WsTest.php
+++ b/test/Schemes/WsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test\Schemes;
+namespace League\Uri\Test\Schemes;
 
 use League\Uri\Schemes\Ws;
 use PHPUnit_Framework_TestCase;

--- a/test/UriParserTest.php
+++ b/test/UriParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\test;
+namespace League\Uri\Test;
 
 use InvalidArgumentException;
 use League\Uri\UriParser;


### PR DESCRIPTION
This PR
- [x] fixes the namespace of tests, which should be `League\Uri\Test` instead of `League\Uri\test`, as documented in [`composer.json`](https://github.com/thephpleague/uri/blob/master/composer.json#L39)
- [x] disables the `psr0` fixer (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1329)
