### PR TITLE
Fix: Update composer itself and validate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - composer self-update
+  - composer validate
+
 install:
   - travis_retry composer install --prefer-dist
 


### PR DESCRIPTION
This PR
- [x] updates Composer itself and validates `composer.json` in `before_install` section

:information_desk_person: Just to make sure, right?
