### PR TITLE
Enhancement: Add Makefile with cs and test targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We accept bug reports via issues created on [Github](https://github.com/thephple
 
 We accept contributions via Pull Requests on [Github](https://github.com/thephpleague/uri/pull).
 
-- **[PSR-2 Coding Standard](http://www.php-fig.org/psr/psr-2/)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://packagist.org/packages/squizlabs/php_codesniffer).
+- **[PSR-2 Coding Standard](http://www.php-fig.org/psr/psr-2/)** 
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
@@ -41,9 +41,18 @@ We accept contributions via Pull Requests on [Github](https://github.com/thephpl
 
 ## Running Tests
 
+Run 
+
 ``` bash
-$ phpunit
+$ make test
 ```
 
+## Fixing Code Style violations
+
+Run
+
+```bash
+$ make cs
+```
 
 **Happy coding**!

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: composer cs test
+
+composer:
+	composer validate
+	composer install --prefer-dist
+
+cs: composer
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+
+test: composer
+	vendor/bin/phpunit --configuration phpunit.xml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Testing
 `League\Uri` has a [PHPUnit](https://phpunit.de) test suite. To run the tests, run the following command from the project folder.
 
 ``` bash
-$ phpunit
+$ make test
 ```
 
 Contributing


### PR DESCRIPTION
This PR
- [x] adds a `Makefile` with `cs` and `test` targets
- [x] updates `CONTRIBUTING.md`
- [x] updates `README.md`

:information_desk_person: Since we're lazy, both targets depend on a `composer` target, which validates `composer.json` and `composer.lock`, as well as installs dependencies.
