### PR TITLE
Fix Typo

### DIFF
--- a/src/Components/PathTrait.php
+++ b/src/Components/PathTrait.php
@@ -31,7 +31,7 @@ trait PathTrait
     /**
      * Typecode value
      *
-     * @array
+     * @var array
      */
     protected static $typecodeList = [
         'a' => PathInterface::FTP_TYPE_ASCII,


### PR DESCRIPTION
Without this fix, i get the following error:

```
The annotation \"@array\" in property League\\Uri\\Components\\HierarchicalPath::$typecodeList was never imported. Did you maybe forget to add a \"use\" statement for this annotation?
```
