### PR TITLE
Improve numeric query support

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -221,12 +221,12 @@ class Formatter
         $auth = $this->formatAuthority($uri);
 
         $query = $this->formatUriPart(new Query($uri->getQuery()));
-        if (!empty($query)) {
+        if ($query !== '') {
             $query = '?'.$query;
         }
 
         $fragment = $uri->getFragment();
-        if (!empty($fragment)) {
+        if ($fragment !== '') {
             $fragment = '#'.$fragment;
         }
 

--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -84,7 +84,8 @@ class QueryParser
         }
 
         if (!array_key_exists($key, $res)) {
-            return array_merge($res, [$key => $value]);
+            $res[$key] = $value;
+            return $res;
         }
 
         if (!is_array($res[$key])) {

--- a/test/FormatterTest.php
+++ b/test/FormatterTest.php
@@ -59,6 +59,17 @@ class FormatterTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, $formatter->format($uri));
     }
 
+    public function testFormatWithZeroes()
+    {
+        $uri       = 'https://example.com/image.jpeg?0#0';
+        $expected  = 'https://example.com/image.jpeg?0#0';
+
+        $uri = HttpUri::createFromString($uri);
+
+        $formatter = new Uri\Formatter();
+        $this->assertSame($expected, $formatter->format($uri));
+    }
+
     public function testFormatComponent()
     {
         $scheme = new Uri\Components\Scheme('ftp');

--- a/test/QueryParserTest.php
+++ b/test/QueryParserTest.php
@@ -46,6 +46,8 @@ class QueryParserTest extends PHPUnit_Framework_TestCase
             'no encoding' => ['a=0&toto=le+heros', '&', false, ['a' => '0', 'toto' => 'le heros']],
             'legacy encoding' => ['john+doe=bar&a=0', '&', PHP_QUERY_RFC1738, ['john doe' => 'bar', 'a' => '0']],
             'different separator' => ['a=0;b=0&c=4', ';', false, ['a' => '0', 'b' => '0&c=4']],
+            'numeric key only' => ['42', '&', PHP_QUERY_RFC3986, ['42' => null]],
+            'numeric key' => ['42=l33t', '&', PHP_QUERY_RFC3986, ['42' => 'l33t']],
         ];
     }
 


### PR DESCRIPTION
Fix issue thephpleague/uri-src#72
- `QueryParser` now is able to parse queries with numeric keys
- UriFormatter now correctly adds a `?` or `#` before the query or fragment, even if the value is `0`, which `empty()` ignored.
