### PR TITLE
Performance: Use preg_match to convert non-unicode characters to lowercase in hostname

### DIFF
--- a/src/Components/HostnameTrait.php
+++ b/src/Components/HostnameTrait.php
@@ -94,7 +94,7 @@ trait HostnameTrait
      */
     protected function lower($str)
     {
-        return preg_replace_callback('/[A-Z]+/', function($matches) {
+        return preg_replace_callback('/[A-Z]+/', function ($matches) {
             return strtolower($matches[0]);
         }, $str);
     }

--- a/src/Components/HostnameTrait.php
+++ b/src/Components/HostnameTrait.php
@@ -94,16 +94,9 @@ trait HostnameTrait
      */
     protected function lower($str)
     {
-        $res = [];
-        for ($i = 0, $length = mb_strlen($str, 'UTF-8'); $i < $length; $i++) {
-            $char = mb_substr($str, $i, 1, 'UTF-8');
-            if (ord($char) < 128) {
-                $char = strtolower($char);
-            }
-            $res[] = $char;
-        }
-
-        return implode('', $res);
+        return preg_replace_callback('/[A-Z]+/', function($matches) {
+            return strtolower($matches[0]);
+        }, $str);
     }
 
     /**


### PR DESCRIPTION
HostnameTrait::lower() is pretty slow, because it's currently doing a lot of work to lowercase only ASCII characters.  Running [this script](https://gist.github.com/rbayliss/95e7e22f699809702e38) through Blackfire locally, I get a 9% speed boost (2.51s vs 2.29s when run using `blackfire run --samples=5 php perf.php`) after applying the following change.  I don't see any downsides, and it still passes all tests.  
