### PR TITLE
Performance: Precompile the ImmutableComponentTrait::encode() regex

### DIFF
--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -87,18 +87,15 @@ class HierarchicalPath extends AbstractHierarchicalComponent implements Hierarch
      */
     protected function validate($data)
     {
-        $data = array_values(array_filter(explode(static::$separator, $data), function ($segment) {
-            return !is_null($segment);
-        }));
+        $regex = $this->getReservedRegex();
 
-        $reserved = implode('', array_map(function ($char) {
-            return preg_quote($char, '/');
-        }, static::$characters_set));
-        $regex = '/(?:[^'.$reserved.']+|%(?![A-Fa-f0-9]{2}))/';
+        // Run the regex on the entire string rather than exploding.
+        // The separator should always be a reserved character.
+        $data = preg_replace_callback($regex, [$this, 'decodeSegmentPart'], $data);
 
-        return array_map(function ($segment) use ($regex) {
-            return preg_replace_callback($regex, [$this, 'decodeSegmentPart'], $segment);
-        }, $data);
+        return array_filter(explode(static::$separator, $data), function ($segment) {
+            return isset($segment);
+        });
     }
 
     /**

--- a/src/Components/Path.php
+++ b/src/Components/Path.php
@@ -66,12 +66,8 @@ class Path extends AbstractComponent implements PathInterface
     {
         $this->assertValidComponent($path);
 
-        $reserved = implode('', array_map(function ($char) {
-            return preg_quote($char, '/');
-        }, static::$characters_set));
-
         return preg_replace_callback(
-            '/(?:[^'.$reserved.']+|%(?![A-Fa-f0-9]{2}))/',
+            $this->getReservedRegex(),
             [$this, 'decodeSegmentPart'],
             $path
         );


### PR DESCRIPTION
This pattern is used in several places:

``` php
$reservedChars = implode('', array_map(function ($value) {
  return preg_quote($value, '/');
}, static::$characters_set));

preg_replace_callback( '/(?:[^'.$reservedChars.']+|%(?![A-Fa-f0-9]{2}))/' ...
```

This regex is being recalculated and rebuilt every time ImmutableComponentTrait::encode(), Path::validate(), or HierarchicalPath::validate() is being called.  Believe it or not, compiling this regex accounts for ~50% of the time spent in [this benchmark](https://gist.github.com/rbayliss/95e7e22f699809702e38).  This PR compiles the entire regex 1x per implementor of ImmutableComponentTrait.  A blackfire run of that benchmark script will show anywhere from a 40-60% reduction in time spent running that script (`blackfire run --samples=5 php perf.php`).  So basically, we get a huge speed boost with no downside that I can see.  
