### PR TITLE
Performance: Avoid using sameValueAs() when setting properties in ImmutablePropertyTrait

### DIFF
--- a/src/Types/ImmutablePropertyTrait.php
+++ b/src/Types/ImmutablePropertyTrait.php
@@ -37,7 +37,7 @@ trait ImmutablePropertyTrait
     protected function withProperty($property, $value)
     {
         $value = $this->$property->modify($value);
-        if ($this->$property->sameValueAs($value)) {
+        if ($this->$property === $value) {
             return $this;
         }
         $newInstance = clone $this;


### PR DESCRIPTION
Changing the value of any property of a URL ends up triggering a call to ImmutablePropertyTrait::withProperty().  Inside this method, there's a call to UriPart::sameValueAs(), which ends up cascading a lot of calls down to other methods.  What about just using a direct object comparison instead?  

In [this benchmark](https://gist.github.com/rbayliss/95e7e22f699809702e38), this improves performance 10-20% (as measured by `blackfire run --samples=5 php perf.php`).
