### PR TITLE
Adding __debugInfo and __set_state to improve debugging

### DIFF
--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -90,4 +90,12 @@ abstract class AbstractComponent
     {
         return $this->__toString();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static($properties['data']);
+    }
 }

--- a/src/Components/AbstractHierarchicalComponent.php
+++ b/src/Components/AbstractHierarchicalComponent.php
@@ -206,4 +206,12 @@ abstract class AbstractHierarchicalComponent implements HierarchicalComponent
             array_merge(array_slice($source, 0, $offset), $dest, array_slice($source, $offset + 1))
         );
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::createFromArray($properties['data'], $properties['isAbsolute']);
+    }
 }

--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -393,6 +393,19 @@ class DataPath extends AbstractComponent implements DataPathInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static(static::format(
+            $properties['mimetype'],
+            implode(';', $properties['parameters']),
+            $properties['isBinaryData'],
+            $properties['document']
+        ));
+    }
+
+    /**
      * Return an instance with the specified mediatype parameters.
      *
      * This method MUST retain the state of the current instance, and return

--- a/src/Components/Host.php
+++ b/src/Components/Host.php
@@ -309,4 +309,17 @@ class Host extends AbstractHierarchicalComponent implements HostInterface
             $this->toArray()
         ));
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        $host = static::createFromArray($properties['data'], $properties['isAbsolute']);
+        if (!$properties['isIdn']) {
+            return $host->toAscii();
+        }
+
+        return $host;
+    }
 }

--- a/src/Components/HostIpTrait.php
+++ b/src/Components/HostIpTrait.php
@@ -46,7 +46,7 @@ trait HostIpTrait
      *
      * @var string
      */
-    protected static $local_link_prefix = '1111111010';
+    protected static $localLinkPrefix = '1111111010';
 
     /**
      * Validate a Host as an IP
@@ -141,7 +141,7 @@ trait HostIpTrait
         };
         $res = array_reduce(str_split(unpack('A16', inet_pton($ipv6))[1]), $convert, '');
 
-        return substr($res, 0, 10) === self::$local_link_prefix;
+        return substr($res, 0, 10) === self::$localLinkPrefix;
     }
 
     /**

--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -200,4 +200,12 @@ class Query implements QueryInterface
 
         return static::createFromArray($data);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::createFromArray($properties['data']);
+    }
 }

--- a/src/Components/UserInfo.php
+++ b/src/Components/UserInfo.php
@@ -167,6 +167,14 @@ class UserInfo implements UserInfoInterface
     /**
      * @inheritdoc
      */
+    public static function __set_state(array $properties)
+    {
+        return new static($properties['user'], $properties['pass']);
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function assertValidObject()
     {
     }

--- a/src/Schemes/Data.php
+++ b/src/Schemes/Data.php
@@ -145,4 +145,20 @@ class Data extends AbstractUri implements Uri
             new Fragment()
         );
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $components)
+    {
+        return new static(
+            $components['scheme'],
+            $components['userInfo'],
+            $components['host'],
+            $components['port'],
+            $components['path'],
+            $components['query'],
+            $components['fragment']
+        );
+    }
 }

--- a/src/Schemes/Generic/AbstractHierarchicalUri.php
+++ b/src/Schemes/Generic/AbstractHierarchicalUri.php
@@ -109,4 +109,20 @@ abstract class AbstractHierarchicalUri extends AbstractUri
             new Fragment($components['fragment'])
         );
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $components)
+    {
+        return new static(
+            $components['scheme'],
+            $components['userInfo'],
+            $components['host'],
+            $components['port'],
+            $components['path'],
+            $components['query'],
+            $components['fragment']
+        );
+    }
 }

--- a/src/Schemes/Generic/AbstractUri.php
+++ b/src/Schemes/Generic/AbstractUri.php
@@ -20,6 +20,7 @@ use League\Uri\Interfaces\Query;
 use League\Uri\Interfaces\Scheme;
 use League\Uri\Interfaces\UserInfo;
 use League\Uri\Types\ImmutablePropertyTrait;
+use League\Uri\UriParser;
 use RuntimeException;
 
 /**
@@ -503,6 +504,14 @@ abstract class AbstractUri
         }
 
         return $this->userInfo->getUriComponent().$this->host->getUriComponent().$port;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return (new UriParser())->__invoke($this);
     }
 
     /**

--- a/test/Components/DataPathTest.php
+++ b/test/Components/DataPathTest.php
@@ -46,6 +46,8 @@ class DataPathTest extends PHPUnit_Framework_TestCase
     {
         $uri = Path::createFromPath(dirname(__DIR__).'/data/'.$path);
         $this->assertSame($expected, $uri->getMimeType());
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function validFilePath()
@@ -111,6 +113,8 @@ class DataPathTest extends PHPUnit_Framework_TestCase
     public function testToAscii($uri)
     {
         $this->assertFalse($uri->toAscii()->isBinaryData());
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function fileProvider()

--- a/test/Components/FragmentTest.php
+++ b/test/Components/FragmentTest.php
@@ -20,6 +20,8 @@ class FragmentTest extends PHPUnit_Framework_TestCase
     {
         $fragment = new Fragment($str);
         $this->assertSame($encoded, $fragment->getUriComponent());
+        eval('$var = '.var_export($fragment, true).';');
+        $this->assertEquals($var, $fragment);
     }
 
     public function validFragment()

--- a/test/Components/HierarchicalPathTest.php
+++ b/test/Components/HierarchicalPathTest.php
@@ -22,6 +22,8 @@ class HierarchicalPathTest extends PHPUnit_Framework_TestCase
     {
         $path = new Path($raw);
         $this->assertSame($parsed, $path->__toString());
+        eval('$var = '.var_export($path, true).';');
+        $this->assertEquals($var, $path);
     }
 
     public function validPathProvider()

--- a/test/Components/HostTest.php
+++ b/test/Components/HostTest.php
@@ -29,6 +29,8 @@ class HostTest extends PHPUnit_Framework_TestCase
         $this->assertSame($isIpv4, $host->isIpv4());
         $this->assertSame($isIpv6, $host->isIpv6());
         $this->assertSame($uri, $host->getUriComponent());
+        eval('$var = '.var_export($host, true).';');
+        $this->assertEquals($var, $host);
     }
 
     public function validHostProvider()

--- a/test/Components/PassTest.php
+++ b/test/Components/PassTest.php
@@ -18,7 +18,10 @@ class PassTest extends PHPUnit_Framework_TestCase
      */
     public function testGetUriComponent($raw, $parsed)
     {
-        $this->assertSame($parsed, (new Pass($raw))->getUriComponent());
+        $pass = new Pass($raw);
+        $this->assertSame($parsed, $pass->getUriComponent());
+        eval('$var = '.var_export($pass, true).';');
+        $this->assertEquals($var, $pass);
     }
 
     public function validUserProvider()

--- a/test/Components/PathTest.php
+++ b/test/Components/PathTest.php
@@ -23,6 +23,8 @@ class PathTest extends PHPUnit_Framework_TestCase
         $property->setAccessible(true);
         $property->setValue($path, null);
         $this->assertSame($parsed, $path->getUriComponent());
+        eval('$var = '.var_export($path, true).';');
+        $this->assertEquals($var, $path);
     }
 
     public function validPathEncoding()

--- a/test/Components/PortTest.php
+++ b/test/Components/PortTest.php
@@ -14,6 +14,8 @@ class PortTest extends PHPUnit_Framework_TestCase
     {
         $port = new Port(new Port(443));
         $this->assertSame('443', $port->__toString());
+        eval('$var = '.var_export($port, true).';');
+        $this->assertEquals($var, $port);
     }
 
     /**

--- a/test/Components/QueryTest.php
+++ b/test/Components/QueryTest.php
@@ -101,6 +101,8 @@ class QueryTest extends PHPUnit_Framework_TestCase
     {
         $query = $this->query->merge($input);
         $this->assertSame($expected, (string) $query);
+        eval('$var = '.var_export($query, true).';');
+        $this->assertEquals($var, $query);
     }
 
     public function validMergeValue()

--- a/test/Components/SchemeTest.php
+++ b/test/Components/SchemeTest.php
@@ -16,6 +16,8 @@ class SchemeTest extends PHPUnit_Framework_TestCase
         $http_scheme = $scheme->modify('HTTP');
         $this->assertSame('http', $http_scheme->__toString());
         $this->assertSame('http:', $http_scheme->getUriComponent());
+        eval('$var = '.var_export($scheme, true).';');
+        $this->assertEquals($var, $scheme);
     }
 
     public function testEmptyScheme()

--- a/test/Components/UserInfoTest.php
+++ b/test/Components/UserInfoTest.php
@@ -26,6 +26,8 @@ class UserInfoTest extends PHPUnit_Framework_TestCase
     public function testSameValueAs($userinfo, $userinfobis, $expected)
     {
         $this->assertSame($expected, $userinfo->sameValueAs($userinfobis));
+        eval('$var = '.var_export($userinfobis, true).';');
+        $this->assertEquals($var, $userinfobis);
     }
 
     public function sameValueAsProvider()

--- a/test/Components/UserTest.php
+++ b/test/Components/UserTest.php
@@ -20,6 +20,8 @@ class UserTest extends PHPUnit_Framework_TestCase
     {
         $user = new User($raw);
         $this->assertSame($parsed, $user->getUriComponent());
+        eval('$var = '.var_export($user, true).';');
+        $this->assertEquals($var, $user);
     }
 
     public function validUserProvider()

--- a/test/Schemes/DataTest.php
+++ b/test/Schemes/DataTest.php
@@ -28,6 +28,8 @@ class DataTest extends PHPUnit_Framework_TestCase
         $this->assertSame($isBinaryData, $uri->path->isBinaryData());
         $this->assertInstanceOf('League\Uri\Interfaces\Scheme', $uri->scheme);
         $this->assertInstanceOf('League\Uri\Interfaces\DataPath', $uri->path);
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function validStringUri()

--- a/test/Schemes/FtpTest.php
+++ b/test/Schemes/FtpTest.php
@@ -18,7 +18,10 @@ class FtpTest extends PHPUnit_Framework_TestCase
      */
     public function testCreateFromString($expected, $input)
     {
-        $this->assertSame($expected, FtpUri::createFromString($input)->__toString());
+        $uri = FtpUri::createFromString($input);
+        $this->assertSame($expected, $uri->__toString());
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function validArray()

--- a/test/Schemes/Generic/UriTest.php
+++ b/test/Schemes/Generic/UriTest.php
@@ -5,6 +5,7 @@ namespace League\Uri\Test\Schemes\Generic;
 use InvalidArgumentException;
 use League\Uri\Components;
 use League\Uri\Schemes\Http as HttpUri;
+use League\Uri\UriParser;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -182,5 +183,10 @@ class UriTest extends PHPUnit_Framework_TestCase
     {
         $expected = '//0:0@0/0?0#0';
         $this->assertSame($expected, HttpUri::createFromString($expected)->__toString());
+    }
+
+    public function testDebugInfo()
+    {
+        $this->assertSame((new UriParser())->__invoke($this->uri), $this->uri->__debugInfo());
     }
 }

--- a/test/Schemes/HttpTest.php
+++ b/test/Schemes/HttpTest.php
@@ -18,7 +18,10 @@ class HttpTest extends PHPUnit_Framework_TestCase
      */
     public function testCreateFromServer($expected, $input)
     {
-        $this->assertSame($expected, HttpUri::createFromServer($input)->__toString());
+        $uri = HttpUri::createFromServer($input);
+        $this->assertSame($expected, $uri->__toString());
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function validServerArray()

--- a/test/Schemes/WsTest.php
+++ b/test/Schemes/WsTest.php
@@ -17,7 +17,10 @@ class WsTest extends PHPUnit_Framework_TestCase
      */
     public function testCreateFromString($expected, $input)
     {
-        $this->assertSame($expected, Ws::createFromString($input)->__toString());
+        $uri = Ws::createFromString($input);
+        $this->assertSame($expected, $uri->__toString());
+        eval('$var = '.var_export($uri, true).';');
+        $this->assertEquals($var, $uri);
     }
 
     public function validUrlArray()


### PR DESCRIPTION
This PR adds PHP's magic method to enable better debugging by implementing [__debugInfo](http://php.net/manual/en/language.oop5.magic.php#object.debuginfo) and [__set_state methods](http://php.net/manual/en/language.oop5.magic.php#object.set-state)
