### PR TITLE
Adding PHP magic methods

### DIFF
--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -32,6 +32,14 @@ abstract class AbstractComponent
     protected $data;
 
     /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static($properties['data']);
+    }
+
+    /**
      * new instance
      *
      * @param string|null $data the component value

--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -432,4 +432,17 @@ class DataPath extends AbstractComponent implements DataPathInterface
             base64_encode(file_get_contents($path))
         ));
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static(static::format(
+            $properties['mimetype'],
+            implode(';', $properties['parameters']),
+            $properties['isBinaryData'],
+            $properties['document']
+        ));
+    }
 }

--- a/src/Components/Fragment.php
+++ b/src/Components/Fragment.php
@@ -28,6 +28,14 @@ class Fragment extends AbstractComponent implements FragmentInterface
     protected static $reservedCharactersRegex = "\!\$&'\(\)\*\+,;\=\:\/@\?";
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['fragment' => $this->__toString()];
+    }
+
+    /**
      * Returns the instance string representation
      * with its optional URI delimiters
      *

--- a/src/Components/HierarchicalPath.php
+++ b/src/Components/HierarchicalPath.php
@@ -100,6 +100,17 @@ class HierarchicalPath extends AbstractHierarchicalComponent implements Hierarch
         return $default;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::createFromArray($properties['data'], $properties['isAbsolute']);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function __toString()
     {
         $front_delimiter = '';

--- a/src/Components/Host.php
+++ b/src/Components/Host.php
@@ -195,6 +195,22 @@ class Host extends AbstractHierarchicalComponent implements HostInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['host' => $this->__toString()];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::createFromArray($properties['data'], $properties['isAbsolute']);
+    }
+
+    /**
      * Returns a host in his punycode encoded form
      *
      * This method MUST retain the state of the current instance, and return

--- a/src/Components/Pass.php
+++ b/src/Components/Pass.php
@@ -26,4 +26,12 @@ class Pass extends AbstractComponent implements PassInterface
      * @inheritdoc
      */
     protected static $invalidCharactersRegex = ',[/?#@],';
+
+    /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['pass' => $this->__toString()];
+    }
 }

--- a/src/Components/PathTrait.php
+++ b/src/Components/PathTrait.php
@@ -73,6 +73,14 @@ trait PathTrait
     abstract public function modify($value);
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['path' => $this->__toString()];
+    }
+
+    /**
      * Returns an instance without dot segments
      *
      * This method MUST retain the state of the current instance, and return

--- a/src/Components/Port.php
+++ b/src/Components/Port.php
@@ -76,4 +76,12 @@ class Port extends AbstractComponent implements PortInterface
     {
         $this->data = $this->validate($data);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['port' => $this->toInt()];
+    }
 }

--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -87,6 +87,22 @@ class Query implements QueryInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['query' => $this->__toString()];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return static::createFromArray($properties['data']);
+    }
+
+    /**
      * Returns the instance string representation; If the
      * instance is not defined an empty string is returned
      *

--- a/src/Components/Scheme.php
+++ b/src/Components/Scheme.php
@@ -41,6 +41,14 @@ class Scheme extends AbstractComponent implements SchemeInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['scheme' => $this->__toString()];
+    }
+
+    /**
      * Returns the instance string representation
      * with its optional URI delimiters
      *

--- a/src/Components/User.php
+++ b/src/Components/User.php
@@ -26,4 +26,12 @@ class User extends AbstractComponent implements UserInterface
      * @inheritdoc
      */
     protected static $invalidCharactersRegex = ',[/:@?#],';
+
+    /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['user' => $this->__toString()];
+    }
 }

--- a/src/Components/UserInfo.php
+++ b/src/Components/UserInfo.php
@@ -77,6 +77,22 @@ class UserInfo implements UserInfoInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return ['userInfo' => $this->__toString()];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static($properties['user'], $properties['pass']);
+    }
+
+    /**
      * Returns the instance string representation; If the
      * instance is not defined an empty string is returned
      *

--- a/src/Schemes/Data.php
+++ b/src/Schemes/Data.php
@@ -145,4 +145,20 @@ class Data extends AbstractUri implements Uri
             new Fragment()
         );
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static(
+            $properties['scheme'],
+            $properties['userInfo'],
+            $properties['host'],
+            $properties['port'],
+            $properties['path'],
+            $properties['query'],
+            $properties['fragment']
+        );
+    }
 }

--- a/src/Schemes/Generic/AbstractHierarchicalUri.php
+++ b/src/Schemes/Generic/AbstractHierarchicalUri.php
@@ -109,4 +109,20 @@ abstract class AbstractHierarchicalUri extends AbstractUri
             new Fragment($components['fragment'])
         );
     }
+
+    /**
+     * @inheritdoc
+     */
+    public static function __set_state(array $properties)
+    {
+        return new static(
+            $properties['scheme'],
+            $properties['userInfo'],
+            $properties['host'],
+            $properties['port'],
+            $properties['path'],
+            $properties['query'],
+            $properties['fragment']
+        );
+    }
 }

--- a/src/Schemes/Generic/AbstractUri.php
+++ b/src/Schemes/Generic/AbstractUri.php
@@ -456,6 +456,23 @@ abstract class AbstractUri
     }
 
     /**
+     * @inheritdoc
+     */
+    public function __debugInfo()
+    {
+        return [
+            'uri' => $this->__toString(),
+            'scheme' => $this->getScheme(),
+            'userInfo' => $this->getUserInfo(),
+            'host' => $this->getHost(),
+            'port' => $this->getPort(),
+            'path' => $this->getPath(),
+            'query' => $this->getQuery(),
+            'fragment' => $this->getFragment(),
+        ];
+    }
+
+    /**
      * Retrieve the scheme specific part of the URI.
      *
      * If no specific part information is present, this method MUST return an empty

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Uri\Test;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class DebugInfoDummyClass
+{
+    public function __debugInfo()
+    {
+        return ['bar'];
+    }
+}
+
+class AbstractTestCase extends TestCase
+{
+    protected function checkRequirements()
+    {
+        parent::checkRequirements();
+        $annotations = $this->getAnnotations();
+        foreach ($annotations as $type => $bag) {
+            if (!array_key_exists('supportsDebugInfo', $bag)) {
+                continue;
+            }
+            if (!$this->supportsDebugInfo()) {
+                $this->markTestSkipped(
+                    'your PHP/HHVM version does not support `__debugInfo`'
+                );
+            }
+        }
+    }
+
+    protected function supportsDebugInfo()
+    {
+        ob_start();
+        var_dump(new DebugInfoDummyClass());
+        $res = ob_get_clean();
+
+        return strpos($res, 'bar') !== false;
+    }
+}

--- a/test/Components/DataPathTest.php
+++ b/test/Components/DataPathTest.php
@@ -4,13 +4,13 @@ namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\DataPath as Path;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 use RuntimeException;
 
 /**
  * @group data
  */
-class DataPathTest extends PHPUnit_Framework_TestCase
+class DataPathTest extends AbstractTestCase
 {
     /**
      * @dataProvider invalidDataUriPath
@@ -180,5 +180,18 @@ class DataPathTest extends PHPUnit_Framework_TestCase
     public function testDataPathConstructor()
     {
         $this->assertSame('text/plain;charset=us-ascii,', (string) new Path());
+    }
+
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $path = new Path();
+        $this->assertInternalType('array', $path->__debugInfo());
+        ob_start();
+        var_dump($path);
+        $res = ob_get_clean();
+        $this->assertContains($path->__toString(), $res);
     }
 }

--- a/test/Components/FragmentTest.php
+++ b/test/Components/FragmentTest.php
@@ -4,12 +4,12 @@ namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Fragment;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group fragment
  */
-class FragmentTest extends PHPUnit_Framework_TestCase
+class FragmentTest extends AbstractTestCase
 {
     /**
      * @dataProvider validFragment
@@ -53,5 +53,19 @@ class FragmentTest extends PHPUnit_Framework_TestCase
             'float'     => [1.2],
             'array'     => [['foo']],
         ];
+    }
+
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Fragment('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('fragment', $res);
     }
 }

--- a/test/Components/HierarchicalPathTest.php
+++ b/test/Components/HierarchicalPathTest.php
@@ -5,14 +5,28 @@ namespace League\Uri\Test\Components;
 use ArrayIterator;
 use InvalidArgumentException;
 use League\Uri\Components\HierarchicalPath as Path;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group path
  * @group hierarchicalpath
  */
-class HierarchicalPathTest extends PHPUnit_Framework_TestCase
+class HierarchicalPathTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Path('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('path', $res);
+    }
+
     /**
      * @param string $raw
      * @param string $parsed

--- a/test/Components/HostTest.php
+++ b/test/Components/HostTest.php
@@ -5,14 +5,28 @@ namespace League\Uri\Test\Components;
 use ArrayIterator;
 use InvalidArgumentException;
 use League\Uri\Components\Host;
+use League\Uri\Test\AbstractTestCase;
 use LogicException;
-use PHPUnit_Framework_TestCase;
 
 /**
  * @group host
  */
-class HostTest extends PHPUnit_Framework_TestCase
+class HostTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Host('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('host', $res);
+    }
+
     /**
      * Test valid Host
      * @param $host

--- a/test/Components/PassTest.php
+++ b/test/Components/PassTest.php
@@ -4,13 +4,27 @@ namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Pass;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group pass
  */
-class PassTest extends PHPUnit_Framework_TestCase
+class PassTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Pass('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('pass', $res);
+    }
+
     /**
      * @dataProvider validUserProvider
      * @param $raw

--- a/test/Components/PathTest.php
+++ b/test/Components/PathTest.php
@@ -4,14 +4,28 @@ namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\Path;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group path
  * @group segmentmodifier
  */
-class PathTest extends PHPUnit_Framework_TestCase
+class PathTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Path('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('path', $res);
+    }
+
     /**
      * @dataProvider validPathEncoding
      */

--- a/test/Components/PortTest.php
+++ b/test/Components/PortTest.php
@@ -3,13 +3,27 @@
 namespace League\Uri\Test\Components;
 
 use League\Uri\Components\Port;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group port
  */
-class PortTest extends PHPUnit_Framework_TestCase
+class PortTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Port(42);
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('port', $res);
+    }
+
     public function testPortSetter()
     {
         $port = new Port(new Port(443));

--- a/test/Components/QueryTest.php
+++ b/test/Components/QueryTest.php
@@ -5,12 +5,12 @@ namespace League\Uri\Test\Components;
 use ArrayIterator;
 use InvalidArgumentException;
 use League\Uri\Components\Query;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group query
  */
-class QueryTest extends PHPUnit_Framework_TestCase
+class QueryTest extends AbstractTestCase
 {
     /**
      * @var Query
@@ -20,6 +20,19 @@ class QueryTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->query = new Query('kingkong=toto');
+    }
+
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $this->assertInternalType('array', $this->query->__debugInfo());
+        ob_start();
+        var_dump($this->query);
+        $res = ob_get_clean();
+        $this->assertContains($this->query->__toString(), $res);
+        $this->assertContains('query', $res);
     }
 
     /**

--- a/test/Components/SchemeTest.php
+++ b/test/Components/SchemeTest.php
@@ -3,13 +3,27 @@
 namespace League\Uri\Test\Components;
 
 use League\Uri\Components\Scheme;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group scheme
  */
-class SchemeTest extends PHPUnit_Framework_TestCase
+class SchemeTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new Scheme('ignace');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('scheme', $res);
+    }
+
     public function testWithValue()
     {
         $scheme = new Scheme('ftp');

--- a/test/Components/UserInfoTest.php
+++ b/test/Components/UserInfoTest.php
@@ -3,13 +3,27 @@
 namespace League\Uri\Test\Components;
 
 use League\Uri\Components\UserInfo;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group userinfo
  */
-class UserInfoTest extends PHPUnit_Framework_TestCase
+class UserInfoTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new UserInfo('yolo', 'oloy');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('userInfo', $res);
+    }
+
     public function testGetterMethod()
     {
         $userinfo = new UserInfo();

--- a/test/Components/UserTest.php
+++ b/test/Components/UserTest.php
@@ -4,13 +4,27 @@ namespace League\Uri\Test\Components;
 
 use InvalidArgumentException;
 use League\Uri\Components\User;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group user
  */
-class UserTest extends PHPUnit_Framework_TestCase
+class UserTest extends AbstractTestCase
 {
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $component = new User('yolo');
+        $this->assertInternalType('array', $component->__debugInfo());
+        ob_start();
+        var_dump($component);
+        $res = ob_get_clean();
+        $this->assertContains($component->__toString(), $res);
+        $this->assertContains('user', $res);
+    }
+
     /**
      * @dataProvider validUserProvider
      * @param $raw

--- a/test/Schemes/DataTest.php
+++ b/test/Schemes/DataTest.php
@@ -175,4 +175,11 @@ class DataTest extends PHPUnit_Framework_TestCase
     {
         DataUri::createFromString('http:text/plain;charset=us-ascii,Bonjour%20le%20monde%21');
     }
+
+    public function testSetState()
+    {
+        $uri = DataUri::createFromPath('test/data/red-nose.gif');
+        $generateUri = eval('return '.var_export($uri, true).';');
+        $this->assertEquals($uri, $generateUri);
+    }
 }

--- a/test/Schemes/FtpTest.php
+++ b/test/Schemes/FtpTest.php
@@ -72,4 +72,11 @@ class FtpTest extends PHPUnit_Framework_TestCase
             ['ftp://example.com?query#fragment'],
         ];
     }
+
+    public function testSetState()
+    {
+        $uri = FtpUri::createFromString('ftp://a:b@c:442/d');
+        $generateUri = eval('return '.var_export($uri, true).';');
+        $this->assertEquals($uri, $generateUri);
+    }
 }

--- a/test/Schemes/Generic/UriTest.php
+++ b/test/Schemes/Generic/UriTest.php
@@ -5,12 +5,12 @@ namespace League\Uri\Test\Schemes\Generic;
 use InvalidArgumentException;
 use League\Uri\Components;
 use League\Uri\Schemes\Http as HttpUri;
-use PHPUnit_Framework_TestCase;
+use League\Uri\Test\AbstractTestCase;
 
 /**
  * @group uri
  */
-class UriTest extends PHPUnit_Framework_TestCase
+class UriTest extends AbstractTestCase
 {
     /**
      * @var HttpUri
@@ -182,5 +182,17 @@ class UriTest extends PHPUnit_Framework_TestCase
     {
         $expected = '//0:0@0/0?0#0';
         $this->assertSame($expected, HttpUri::createFromString($expected)->__toString());
+    }
+
+    /**
+     * @supportsDebugInfo
+     */
+    public function testDebugInfo()
+    {
+        $this->assertInternalType('array', $this->uri->__debugInfo());
+        ob_start();
+        var_dump($this->uri);
+        $res = ob_get_clean();
+        $this->assertContains($this->uri->__toString(), $res);
     }
 }

--- a/test/Schemes/HttpTest.php
+++ b/test/Schemes/HttpTest.php
@@ -223,4 +223,11 @@ class HttpTest extends PHPUnit_Framework_TestCase
             ['wss:/example.com'],
         ];
     }
+
+    public function testSetState()
+    {
+        $uri = HttpUri::createFromString('https://a:b@c:442/d?q=r#f');
+        $generateUri = eval('return '.var_export($uri, true).';');
+        $this->assertEquals($uri, $generateUri);
+    }
 }

--- a/test/Schemes/WsTest.php
+++ b/test/Schemes/WsTest.php
@@ -71,4 +71,11 @@ class WsTest extends PHPUnit_Framework_TestCase
             ['ws://example.com:80/foo/bar?foo=bar#content'],
         ];
     }
+
+    public function testSetState()
+    {
+        $uri = Ws::createFromString('wss://a:b@c:442/d');
+        $generateUri = eval('return '.var_export($uri, true).';');
+        $this->assertEquals($uri, $generateUri);
+    }
 }


### PR DESCRIPTION
To allow better debugging and class reconstruction the following PHP's magic
methods are added to all Schemes specifc and Components classes:
- `__set_state` to enabled using the result of var_export.
- `__debugInfo` to allow better debugging in PHP 5.6+
