### PR TITLE
Fix: Namespace does not match project structure

### DIFF
--- a/test/Modifiers/PipelineTest.php
+++ b/test/Modifiers/PipelineTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Uri\Test;
+namespace League\Uri\Test\Modifiers;
 
 use InvalidArgumentException;
 use League\Uri\Modifiers\Pipeline;


### PR DESCRIPTION
This PR
- [x] fixes a namespace of a test to align it with the project structure
