### PR TITLE
Fix: Duplicate array key in data provider

### DIFF
--- a/test/UriParserTest.php
+++ b/test/UriParserTest.php
@@ -343,7 +343,7 @@ class UriParserTest extends PHPUnit_Framework_TestCase
                     'fragment' => null,
                 ],
             ],
-            'single word is a path' => [
+            'single word is a path, no' => [
                 'http:::/path',
                 [
                     'scheme' => 'http',


### PR DESCRIPTION
This PR
- [x] renames an otherwise duplicate array key in a data provider
