### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/test/Components/QueryTest.php
+++ b/test/Components/QueryTest.php
@@ -17,7 +17,7 @@ class QueryTest extends AbstractTestCase
      */
     protected $query;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->query = new Query('kingkong=toto');
     }

--- a/test/FormatterTest.php
+++ b/test/FormatterTest.php
@@ -19,7 +19,7 @@ class FormatterTest extends PHPUnit_Framework_TestCase
 
     private $formatter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uri = HttpUri::createFromString(
             'http://login:pass@gwóźdź.pl:443/test/query.php?kingkong=toto&foo=bar+baz#doc3'

--- a/test/Modifiers/HostModifierTest.php
+++ b/test/Modifiers/HostModifierTest.php
@@ -23,7 +23,7 @@ class HostModifierTest extends PHPUnit_Framework_TestCase
 {
     private $uri;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uri = HttpUri::createFromString(
             'http://www.example.com/path/to/the/sky.php?kingkong=toto&foo=bar+baz#doc3'

--- a/test/Modifiers/PathModifierTest.php
+++ b/test/Modifiers/PathModifierTest.php
@@ -33,7 +33,7 @@ class PathModifierTest extends PHPUnit_Framework_TestCase
 {
     private $uri;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uri = HttpUri::createFromString(
             'http://www.example.com/path/to/the/sky.php?kingkong=toto&foo=bar+baz#doc3'

--- a/test/Modifiers/QueryModifierTest.php
+++ b/test/Modifiers/QueryModifierTest.php
@@ -19,7 +19,7 @@ class QueryModifierTest extends PHPUnit_Framework_TestCase
 {
     private $uri;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uri = HttpUri::createFromString(
             'http://www.example.com/path/to/the/sky.php?kingkong=toto&foo=bar+baz#doc3'

--- a/test/QueryParserTest.php
+++ b/test/QueryParserTest.php
@@ -12,7 +12,7 @@ class QueryParserTest extends PHPUnit_Framework_TestCase
 {
     protected $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new QueryParser();
     }

--- a/test/Schemes/Generic/UriTest.php
+++ b/test/Schemes/Generic/UriTest.php
@@ -17,14 +17,14 @@ class UriTest extends AbstractTestCase
      */
     private $uri;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uri = HttpUri::createFromString(
             'http://login:pass@secure.example.com:443/test/query.php?kingkong=toto#doc3'
         );
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->uri = null;
     }

--- a/test/UriParserTest.php
+++ b/test/UriParserTest.php
@@ -13,7 +13,7 @@ class UriParserTest extends PHPUnit_Framework_TestCase
 {
     protected $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new UriParser();
     }


### PR DESCRIPTION
This PR
- [x] reduces the visibility of `setUp()` and `tearDown()` from `public` to `protected`

🙎 This is the visibility as defined on the parent; there's no need to increase it.
