### PR TITLE
Update Generic Manipulation Docs

### DIFF
--- a/uri/manipulation/generic.md
+++ b/uri/manipulation/generic.md
@@ -17,7 +17,7 @@ Here's the documentation for the included URI modifiers which are modifying mult
 public Resolve::__construct(mixed $uri)
 ~~~
 
-The `Resolve` URI Modifier provides the mean for resolving an URI as a browser would for an anchor tag. When performing URI resolution the returned URI is normalized according to RFC3986 rules. The uri to resolved must be another Uri object.
+The `Resolve` URI Modifier provides the mean for resolving an URI as a browser would for a relative URI. When performing URI resolution the returned URI is normalized according to RFC3986 rules. The uri to resolved must be another Uri object.
 
 ### Parameters
 
@@ -35,7 +35,7 @@ $baseUri     = HttpUri::createFromString("http://www.example.com/path/to/the/sky
 $relativeUri = HttpUri::createFromString("./p#~toto");
 $modifier    = new Resolve($baseUri);
 $newUri = $modifier->__invoke($relativeUri);
-echo $newUri; //displays "http://www.example.com/hello/p#~toto"
+echo $newUri; //displays "http://www.example.com/path/to/the/sky/p#~toto"
 ~~~
 
 ## Applying multiple modifiers to a single URI


### PR DESCRIPTION
- Change "anchor tag" to "relative URI".
  - URI's can come from multiple HTML tags (including `img`, `link`, `script`, etc).
- Change the comment in the example to show the correct output.

Pick and choose the changes if you want. Did it all in one commit because I don't have Git on this laptop.
