### PR TITLE
Fixes link to CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ composer test
 Contributing
 -------
 
-Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
+Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](.github/CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
 
 Security
 -------


### PR DESCRIPTION
Fixed the link to CONTRIBUTING.md at the bottom of the README file.

```
CONTRIBUTING.md -> .github/CONTRIBUTING.md
```
