### PR TITLE
Change usages of his to its in docblock

### DIFF
--- a/src/Interfaces/Host.php
+++ b/src/Interfaces/Host.php
@@ -112,7 +112,7 @@ interface Host extends HierarchicalComponent
     public function getLabel($offset, $default = null);
 
     /**
-     * Returns a host in his IDN form
+     * Returns a host in its IDN form
      *
      * This method MUST retain the state of the current instance, and return
      * an instance with the host in its IDN form using RFC 3492 rules
@@ -124,7 +124,7 @@ interface Host extends HierarchicalComponent
     public function toUnicode();
 
     /**
-     * Returns a host in his punycode encoded form
+     * Returns a host in its punycode encoded form
      *
      * This method MUST retain the state of the current instance, and return
      * an instance with the host transcoded using to ascii the RFC 3492 rules


### PR DESCRIPTION
## Introduction

Fixes grammar issues in docblocks.
## Proposal
### Describe the new/upated/fixed feature

Changes uses of `his` to `its` when the pronoun references the host. I think this has two benefits. I think it's generally appreciated to use gender neutral pronouns and secondly its the pronoun used in `withoutZoneIdentifier` so the documentation is more consistent.
### Backward Incompatible Changes

None
### Targeted release version

4.1.2
### PR Impact

None
## Open issues

None
