### PR TITLE
Add `toString` alias for `__toString`

### DIFF
--- a/src/Schemes/Generic/AbstractUri.php
+++ b/src/Schemes/Generic/AbstractUri.php
@@ -258,6 +258,14 @@ abstract class AbstractUri
     }
 
     /**
+     * @inheritdoc
+     */
+    public function toString()
+    {
+        return $this->__toString();
+    }
+
+    /**
      * Retrieve the scheme specific part of the URI.
      *
      * If no specific part information is present, this method MUST return an empty


### PR DESCRIPTION
## Introduction

We really love this library and started using it on some places in our application. 
## Proposal
### Describe the new/upated/fixed feature

It bugs me to see the `__toString()` everywhere. So I propose to create a nice alias called `toString`. It makes it a bit nicer, IMO.
### Backward Incompatible Changes

None
### Targeted release version

None
### PR Impact

Just a convenience alias
