### PR TITLE
Add failing test for withPath

### DIFF
--- a/test/Schemes/Generic/UriTest.php
+++ b/test/Schemes/Generic/UriTest.php
@@ -170,6 +170,42 @@ class UriTest extends AbstractTestCase
             ->withPath('//toto');
     }
 
+    public function testWithPathWithEmptyString()
+    {
+        $uri = HttpUri::createFromString('http://example.com/path');
+
+        $modified = $uri->withPath('');
+
+        $this->assertNotSame($uri, $modified);
+
+        $this->assertSame('/path', $uri->getPath());
+        $this->assertSame('', $modified->getPath());
+    }
+
+    public function testWithPathWithAbsolutePath()
+    {
+        $uri = HttpUri::createFromString('http://example.com/path');
+
+        $modified = $uri->withPath('/new-path');
+
+        $this->assertNotSame($uri, $modified);
+
+        $this->assertSame('/path', $uri->getPath());
+        $this->assertSame('/new-path', $modified->getPath());
+    }
+
+    public function testWithPathWithRootlessPath()
+    {
+        $uri = HttpUri::createFromString('http://example.com/path');
+
+        $modified = $uri->withPath('new-path');
+
+        $this->assertNotSame($uri, $modified);
+
+        $this->assertSame('/path', $uri->getPath());
+        $this->assertSame('/new-path', $modified->getPath());
+    }
+
     public function testEmptyValueDetection()
     {
         $expected = '//0:0@0/0?0#0';


### PR DESCRIPTION
Since version 4.2.0 `withPath` is throwing `InvalidArgumentException` for "rootless" paths

As described in [PSR-7 message interface](https://github.com/php-fig/http-message/blob/master/src/UriInterface.php#L248-L250) 

>The path can either be empty or absolute (starting with a slash) 
rootless (not starting with a slash). Implementations MUST support all
three syntaxes.

I've just added tests that cover 3 usages of  `withPath` method as stated above. Didn't figure out what change exactly introduced this issue, if you can help with pointing out the commit I'll try to fix this issue


