### PR TITLE
Bug fix issue #91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All Notable changes to `League\Uri` will be documented in this file
 
+## Next
+
+### Added
+
+- Nothing
+
+### Fixed
+
+- issue [#91](https://github.com/thephpleague/uri/issues/91) Path modifier must be RFC3986 compliant
+
+### Deprecated
+
+- Nothing
+
+### Remove
+
+- Nothing
+
 ## 4.2.1 - 2016-11-24
 
 ### Added

--- a/src/Modifiers/AbstractPathModifier.php
+++ b/src/Modifiers/AbstractPathModifier.php
@@ -34,6 +34,12 @@ abstract class AbstractPathModifier extends AbstractPartialUriModifier
     {
         $this->assertUriObject($uri);
 
-        return $uri->withPath($this->modify($uri->getPath()));
+        $path = $this->modify($uri->getPath());
+        if ('' != $uri->getAuthority() && '' != $path && '/' != $path[0]) {
+            $path = '/'.$path;
+        }
+
+
+        return $uri->withPath($path);
     }
 }

--- a/test/Modifiers/PathModifierTest.php
+++ b/test/Modifiers/PathModifierTest.php
@@ -107,6 +107,42 @@ class PathModifierTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider validAppendPathProvider
+     */
+    public function testAppendProcessWithRelativePath($uri, $segment, $expected)
+    {
+        $modifier = new AppendSegment('new-segment');
+        $uri = HttpUri::createFromString('http://www.example.com');
+        $this->assertSame('http://www.example.com/new-segment', (string) $modifier($uri));
+    }
+
+    public function validAppendPathProvider()
+    {
+        return [
+            'uri with trailing slash' => [
+                'uri' => 'http://www.example.com/report/',
+                'segment' => 'new-segment',
+                'expected' => 'http://www.example.com/report/new-segment',
+            ],
+            'uri with path without trailing slash' => [
+                'uri' => 'http://www.example.com/report',
+                'segment' => 'new-segment',
+                'expected' => 'http://www.example.com/report/new-segment',
+            ],
+            'uri with absolute path' => [
+                'uri' => 'http://www.example.com/',
+                'segment' => 'new-segment',
+                'expected' => 'http://www.example.com/new-segment',
+            ],
+            'uri with empty path' => [
+                'uri' => 'http://www.example.com',
+                'segment' => 'new-segment',
+                'expected' => 'http://www.example.com/new-segment',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider validPathProvider
      *
      * @param string $segment


### PR DESCRIPTION
## Introduction

Issue thephpleague/uri-src#49 

## Proposal

Path Modifiers are made RFC3986 compliant: if an authority is present the path must be empty or start with a `/`

### Backward Incompatible Changes

- none

### Targeted release version

next patch release (4.2.2)

### PR Impact

- none

## Open issues

- none