### PR TITLE
Workaround deprecated variant in `idn_to_*` functions & PHP 7.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
     - php: 7.1
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
+    - php: 7.2
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
     - php: hhvm
       env: COLLECT_COVERAGE=false VALIDATE_CODING_STYLE=false
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring" : "*",
         "ext-intl" : "*",
         "ext-fileinfo": "*",
-        "jeremykendall/php-domain-parser": "^3.0",
+        "jeremykendall/php-domain-parser": "4.0.3-alpha",
         "php" : ">=5.5.9",
         "psr/http-message": "^1.0"
     },

--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -132,6 +132,10 @@ class DataPath extends AbstractComponent implements DataPathInterface
             throw new InvalidArgumentException(sprintf('invalid mimeType, `%s`', $mimetype));
         }
 
+        if ($mimetype === 'text/vcard') {
+            $mimetype = 'text/x-vcard';
+        }
+
         return $mimetype;
     }
 

--- a/src/Components/DataPath.php
+++ b/src/Components/DataPath.php
@@ -132,10 +132,6 @@ class DataPath extends AbstractComponent implements DataPathInterface
             throw new InvalidArgumentException(sprintf('invalid mimeType, `%s`', $mimetype));
         }
 
-        if ($mimetype === 'text/vcard') {
-            $mimetype = 'text/x-vcard';
-        }
-
         return $mimetype;
     }
 

--- a/src/Components/Host.php
+++ b/src/Components/Host.php
@@ -266,7 +266,15 @@ class Host extends AbstractHierarchicalComponent implements HostInterface
     public function getLabel($offset, $default = null)
     {
         if (isset($this->data[$offset])) {
-            return $this->isIdn ? rawurldecode($this->data[$offset]) : idn_to_ascii($this->data[$offset]);
+            if ($this->isIdn) {
+                return rawurldecode($this->data[$offset]);
+            }
+
+            if (PHP_VERSION_ID >= 70200) {
+                return @idn_to_ascii($this->data[$offset]);
+            }
+
+            return idn_to_ascii($this->data[$offset]);
         }
 
         return $default;

--- a/src/Components/HostnameTrait.php
+++ b/src/Components/HostnameTrait.php
@@ -45,7 +45,7 @@ trait HostnameTrait
 
         foreach ($labels as &$label) {
             if ('' !== $label) {
-                $label = idn_to_ascii($label);
+                $label = PHP_VERSION_ID >= 70200 ? @idn_to_ascii($label) : idn_to_ascii($label);
             }
         }
         unset($label);
@@ -65,14 +65,14 @@ trait HostnameTrait
         $host = $this->lower($this->setIsAbsolute($str));
         $raw_labels = explode('.', $host);
         $labels = array_map(function ($value) {
-            return idn_to_ascii($value);
+            return PHP_VERSION_ID >= 70200 ? @idn_to_ascii($value) : idn_to_ascii($value);
         }, $raw_labels);
 
         $this->assertValidHost($labels);
         $this->isIdn = $raw_labels !== $labels;
 
         return array_reverse(array_map(function ($label) {
-            return idn_to_utf8($label);
+            return PHP_VERSION_ID >= 70200 ? @idn_to_utf8($label) : idn_to_utf8($label);
         }, $labels));
     }
 

--- a/test/Components/DataPathTest.php
+++ b/test/Components/DataPathTest.php
@@ -46,15 +46,15 @@ class DataPathTest extends AbstractTestCase
     public function testCreateFromPath($path, $expected)
     {
         $uri = Path::createFromPath(dirname(__DIR__).'/data/'.$path);
-        $this->assertSame($expected, $uri->getMimeType());
+        $this->assertContains($uri->getMimeType(), $expected);
     }
 
     public function validFilePath()
     {
         return [
-            'text file' => ['hello-world.txt', 'text/plain'],
-            'img file' => ['red-nose.gif', 'image/gif'],
-            'vcard file' => ['john-doe.vcf', 'text/x-vcard'],
+            'text file' => ['hello-world.txt', ['text/plain']],
+            'img file' => ['red-nose.gif', ['image/gif']],
+            'vcard file' => ['john-doe.vcf', ['text/x-vcard', 'text/vcard']],
         ];
     }
 


### PR DESCRIPTION
As discussed in thephpleague/uri-src#41.