### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `League\Uri` will be documented in this file
 
-## 2.0.0 - 2019-10-18
+## 6.0.0 - 2019-10-18
 
 ### Added
 


### PR DESCRIPTION
The version available in composer appears to be 6.0.0 so I assume this is a typo.