### PR TITLE
Don't modify internal state when calling __toString

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -277,9 +277,9 @@ final class Uri implements UriInterface
     /**
      * URI string representation.
      *
-     * @var string|null
+     * @var string
      */
-    private $uri;
+    private $uri = '';
 
     /**
      * Create a new instance.
@@ -1106,7 +1106,13 @@ final class Uri implements UriInterface
 
         $validationMethod = self::SCHEME_VALIDATION_METHOD[$this->scheme] ?? null;
         if (null === $validationMethod || true === $this->$validationMethod()) {
-            $this->uri = null;
+            $this->uri = $this->getUriString(
+                $this->scheme,
+                $this->authority,
+                $this->path,
+                $this->query,
+                $this->fragment
+            );
 
             return;
         }
@@ -1204,14 +1210,6 @@ final class Uri implements UriInterface
      */
     public function __toString(): string
     {
-        $this->uri = $this->uri ?? $this->getUriString(
-            $this->scheme,
-            $this->authority,
-            $this->path,
-            $this->query,
-            $this->fragment
-        );
-
         return $this->uri;
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -563,4 +563,11 @@ class UriTest extends TestCase
             'invalid-enc' => ['%ZZ', '%GG', '%25ZZ:%25GG'],
         ];
     }
+
+    public function testToStringShouldNotModifyInternalState(): void
+    {
+        $uri = Uri::createFromString('https://github.com/thephpleague/uri');
+        $uri->__toString();
+        self::assertEquals($uri, Uri::createFromString('https://github.com/thephpleague/uri'));
+    }
 }


### PR DESCRIPTION
I'm creating a test suite that serializes all my commands (for command handlers) to JSON and then deserializes them back to find out if the deserialized object is still equal to the original object.

While doing that, I found a weird quirk in the `Uri` object:
<img width="1090" alt="Screenshot 2019-11-02 at 16 12 12" src="https://user-images.githubusercontent.com/104180/68072956-92ff5800-fd8b-11e9-816f-ee94f20133d0.png">
The left shows the original object (that has been serialized to JSON) and the right one shows the deserialized object (from JSON).

I found out that the internal state of the `Uri` object on the left side changes when calling `__toString`. 

After digging in I discovered that the `__toString` method uses a private `$uri` property to cache the string representation of the `Uri`. Instead of doing this, I think it would be better to have this fixed (when creating the object).

That's why I moved this over to the `assertValidState` method that is called after construction and after every `clone`.