### PR TITLE
Do not expand undefined URI template variables.

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -402,7 +402,9 @@ final class UriTemplate
         $parts = [];
         /** @var array{name:string, modifier:string, position:string} $variable */
         foreach ($expression['variables'] as $variable) {
-            $parts[] = $this->expandVariable($variable, $expression['operator'], $joiner, $useQuery);
+            if (isset($this->variables[$variable['name']])) {
+                $parts[] = $this->expandVariable($variable, $expression['operator'], $joiner, $useQuery);
+            }
         }
 
         $nullFilter = static function ($value): bool {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -224,6 +224,7 @@ final class UriTemplateTest extends TestCase
                 ['{;x,y,empty}',        ';x=1024;y=768;empty'],
                 ['{?x,y}',              '?x=1024&y=768'],
                 ['{?x,y,empty}',        '?x=1024&y=768&empty='],
+                ['{?x,y,undef}',        '?x=1024&y=768'],
                 ['?fixed=yes{&x}',      '?fixed=yes&x=1024'],
                 ['{&x,y,empty}',        '&x=1024&y=768&empty='],
             ],


### PR DESCRIPTION
Hello 👋! I am really excited to have found that the league has an implementation of [RFC 6570 - URI Template](https://tools.ietf.org/html/rfc6570#section-3.2.1, especially since the Guzzle implementation will be removed. However, when I changed from Guzzle's implementation to this one, I think I found a slight bug/incompatibility.

RFC6570 states that:

> A variable that is undefined (Section 2.3) has no value and is _ignored by the expansion process_.  If all of the variables in an expression are undefined, then the expression's expansion is the empty string. (emphasis mine)

Therefore, if I wrote the following: 

```php
$template = new UriTemplate('{?x,y,undef}');
$params = [
  'x' => 'foo',
  'y' => 42,
];
echo (string) $template->expand($params), PHP_EOL;
```

I would expect the expanded URI to be:

```
?x=foo&y=42
```

... given that the variable `undef` is not defined in my parameter array.

However, what I actually see is that the URI is expanded to:

```
?x=foo&y=42&undef=
```

For comparison, this online URI template tester gives my expected results:  https://spooky.github.io/uri-template-tester/

You can try it with:
`http://example.org/test{?x,y,undef}`
```json
{
  "x": "foo",
  "y": 42
}
```
You should get `http://example.org/test?x=foo&y=42` as shown below.

![screenshot of the URI template tester showing the above](https://user-images.githubusercontent.com/4500265/75595815-1899c880-5a4b-11ea-806e-1288165d6e48.png)