### PR TITLE
bug fix issue #171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ imporove `UriTemplate` implementation.
 
 - `UriTemplate` complete rewrite by reducing deep nested array usage.
 - Exception misleading message see issue [#167](https://github.com/thephpleague/uri/issues/167)
+- `Uri::withScheme` Uri validation failed to catch the empty string as an invalid scheme.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "ext-json": "*",
         "psr/http-message": "^1.0",
         "league/uri-interfaces": "^2.1"

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -310,7 +310,7 @@ final class Uri implements UriInterface
      */
     private function formatScheme(?string $scheme): ?string
     {
-        if ('' === $scheme || null === $scheme) {
+        if (null === $scheme) {
             return $scheme;
         }
 
@@ -319,7 +319,7 @@ final class Uri implements UriInterface
             return $formatted_scheme;
         }
 
-        throw new SyntaxError(sprintf('The scheme `%s` is invalid', $scheme));
+        throw new SyntaxError(sprintf('The scheme `%s` is invalid.', $scheme));
     }
 
     /**
@@ -438,7 +438,7 @@ final class Uri implements UriInterface
             $arr
         );
 
-        if ($arr === []) {
+        if ([] === $arr) {
             throw new SyntaxError(sprintf('Host `%s` is invalid', $host));
         }
 

--- a/src/UriString.php
+++ b/src/UriString.php
@@ -472,7 +472,7 @@ final class UriString
 
         $retval = idn_to_ascii($formatted_host, 0, INTL_IDNA_VARIANT_UTS46, $arr);
 
-        if ($arr === []) {
+        if ([] === $arr) {
             throw new SyntaxError(sprintf('Host `%s` is not a valid IDN host', $host));
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -580,4 +580,12 @@ class UriTest extends TestCase
 
         Uri::createFromString('file://example.org:80/home/jsmith/foo.txt');
     }
+
+    public function testIssue171TheEmptySchemeShouldThrow(): void
+    {
+        self::expectException(SyntaxError::class);
+        self::expectExceptionMessage('The scheme `` is invalid.');
+
+        Uri::createFromString('domain.com')->withScheme('');
+    }
 }


### PR DESCRIPTION
```php
<?php 

Uri::createFromString('domain.com')->withScheme(''); // should throw
```

Because a scheme is either no declared (ie: `null`) or a specific string following RFC3986. The empty string is a string but it does not follow RFC3986 specification so it should be caught and trigger a `SyntaxError` exception.