### PR TITLE
Improve URL Encoding of Path Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All Notable changes to `League\Uri` will be documented in this file
 
+## 6.3.1 - 2020-11-23
+
+### Added
+
+- None
+
+### Fixed
+
+- Bugfix `Uri::formatPath` to improve URL encoding in the path component [#180](https://github.com/thephpleague/uri/pull/180) thanks [mdawaffe](https://github.com/mdawaffe).
+
+### Deprecated
+
+- Nothing
+
+### Remove
+
+- None
+
 ## 6.3.0 - 2020-08-13
 
 ### Added 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -972,7 +972,7 @@ final class Uri implements UriInterface
     {
         $path = $this->formatDataPath($path);
 
-        static $pattern = '/(?:[^'.self::REGEXP_CHARS_UNRESERVED.self::REGEXP_CHARS_SUBDELIM.'%:@\/}{]++\|%(?![A-Fa-f0-9]{2}))/';
+        static $pattern = '/(?:[^'.self::REGEXP_CHARS_UNRESERVED.self::REGEXP_CHARS_SUBDELIM.'%:@\/}{]++|%(?![A-Fa-f0-9]{2}))/';
 
         $path = (string) preg_replace_callback($pattern, [Uri::class, 'urlEncodeMatch'], $path);
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -145,8 +145,11 @@ final class Uri implements UriInterface
 
     /**
      * Regular expression pattern to for file URI.
+     * <volume> contains the volume but not the volume separator.
+     * The volume separator may be URL-encoded (`|` as `%7C`) by ::formatPath(),
+     * so we account for that here.
      */
-    private const REGEXP_FILE_PATH = ',^(?<delim>/)?(?<root>[a-zA-Z][:|\|])(?<rest>.*)?,';
+    private const REGEXP_FILE_PATH = ',^(?<delim>/)?(?<volume>[a-zA-Z])(?:[:|\|]|%7C)(?<rest>.*)?,';
 
     /**
      * Mimetype regular expression pattern.
@@ -164,6 +167,7 @@ final class Uri implements UriInterface
 
     /**
      * Windows file path string regular expression pattern.
+     * <root> contains both the volume and volume separator.
      */
     private const REGEXP_WINDOW_PATH = ',^(?<root>[a-zA-Z][:|\|]),';
 
@@ -1071,7 +1075,7 @@ final class Uri implements UriInterface
         }
 
         $replace = static function (array $matches): string {
-            return $matches['delim'].str_replace('|', ':', $matches['root']).$matches['rest'];
+            return $matches['delim'].$matches['volume'].':'.$matches['rest'];
         };
 
         return (string) preg_replace_callback(self::REGEXP_FILE_PATH, $replace, $path);

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -550,6 +550,20 @@ class UriTest extends TestCase
     }
 
     /**
+     * @covers ::formatPath
+     */
+    public function testUnreservedCharsInPathUnencoded(): void
+    {
+        $uri = Uri::createFromString('http://www.example.com/')
+            ->withPath('/h"ell\'o/./wor ld<i>/%25abc%xyz');
+
+        self::assertSame(
+            "/h%22ell'o/./wor%20ld%3Ci%3E/%25abc%25xyz",
+            $uri->getPath()
+        );
+    }
+
+    /**
      * @dataProvider userInfoProvider
      * @param ?string $credential
      */


### PR DESCRIPTION
The example at https://uri.thephpleague.com/uri/6.0/rfc3986/#uri-normalization shows how `Uri::createFromString()` can be used to normalize URLs:

```php
$uri = Uri::createFromString(
    "hTTp://www.ExAmPLE.com:80/hello/./wor ld?who=f 3#title"
);
echo $uri; //displays http://www.example.com/hello/./wor%20ld?who=f%203#title
```

Unfortunately, the actual output is not the same as the documented output:
<dl>
<dt>Documented</dt>
<dd><code>http://www.example.com/hello/./wor%20ld?who=f%203#title</code></dd>
<dt>Actual</dt>
<dd><code>http://www.example.com/hello/./wor ld?who=f%203#title</code></dd>
</dl>

(Note the unencoded whitespace in the path component and the correctly encoded query component of the actual output.)

This is caused by some unwanted escaping in `URI::formatPath()`'s regex: https://github.com/thephpleague/uri/blob/1d6a34732d9fc30de27577a7c4129f2d9a3221cc/src/Uri.php#L975

(It should read `|` instead of `\|`.)

This PR corrects that regex and adds a test case.

Unfortunately, that regex change broke another test: one concerning a Windows path syntax I have not encountered before: `C|` instead of the more common `C:`. To fix that test, I've changed how `Uri::formatFilePath()` works, but, being unfamiliar with the syntax, I'm not sure if I've actually fixed the underlying problem or if I've just done enough to pass the existing tests. (Also, the changes I made there are a bit ugly :)).