### PR TITLE
Adding HttpFactory class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All Notable changes to `League\Uri` will be documented in this file
 
-## 6.3.1 - 2020-11-23
+## 6.4.0 - 2020-11-23
 
 ### Added
 
-- None
+- `HttpFactory` a class that implements PSR-17 UriFactoryInterface. The package needs to be present for the class to work.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": ">=7.2",
         "ext-json": "*",
         "psr/http-message": "^1.0",
         "league/uri-interfaces": "^2.1"
@@ -54,7 +54,8 @@
         "phpunit/phpunit" : "^8.0 || ^9.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12"
+        "phpstan/phpstan-phpunit": "^0.12",
+        "psr/http-factory": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -95,7 +96,8 @@
     "suggest": {
         "league/uri-components" : "Needed to easily manipulate URI objects",
         "ext-intl" : "Needed to improve host validation",
-        "ext-fileinfo": "Needed to create Data URI from a filepath"
+        "ext-fileinfo": "Needed to create Data URI from a filepath",
+        "psr/http-factory": "Needed to use the URI factory"
     },
     "extra": {
         "branch-alias": {

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * League.Uri (https://uri.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Uri;
+
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
+
+final class HttpFactory implements UriFactoryInterface
+{
+    public function createUri(string $uri = ''): UriInterface
+    {
+        return Http::createFromString($uri);
+    }
+}

--- a/tests/HttpFactoryTest.php
+++ b/tests/HttpFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * League.Uri (https://uri.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTest\Uri;
+
+use League\Uri\Http;
+use League\Uri\HttpFactory;
+use PHPUnit\Framework\TestCase;
+
+final class HttpFactoryTest extends TestCase
+{
+    public function testCreateUri(): void
+    {
+        $factory = new HttpFactory();
+        $uri = $factory->createUri('https://nyholm.tech/foo');
+
+        self::assertInstanceOf(Http::class, $uri);
+        self::assertEquals('https://nyholm.tech/foo', $uri->__toString());
+    }
+}


### PR DESCRIPTION
Adding HttpFactory as an UriFactoryInterface implementing class.
You will need to require the PSR-17 package for the class to work.