### PR TITLE
Fix api regression in filterInput by accepting null

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -190,6 +190,10 @@ final class Http implements Psr7UriInterface, JsonSerializable
      */
     private function filterInput(mixed $str): string|null
     {
+        if (null === $str) {
+            return null;
+        }
+
         if (!is_scalar($str) && !$str instanceof Stringable) {
             throw new SyntaxError('The component must be a string, a scalar or a Stringable object; `'.gettype($str).'` given.');
         }

--- a/src/HttpTest.php
+++ b/src/HttpTest.php
@@ -73,6 +73,17 @@ final class HttpTest extends UriIntegrationTest
     }
 
     /**
+     * @covers ::filterInput
+     */
+    public function testAcceptsNullQuery(): void
+    {
+        self::assertSame(
+            'https://example.com',
+            (string)Http::createFromString('https://example.com')->withQuery(null) /* @phpstan-ignore-line */
+        );
+    }
+
+    /**
      * @covers ::getPort
      * @covers ::withPort
      */


### PR DESCRIPTION
Although the parameter to `withQuery` is supposed to be a string, according to php doc, before version 6.8.0 a null value was accepted implicitly. Other libraries like spatie/url-signer relied on that behavior. Although it already got fixed for spatie/url-signer in  https://github.com/spatie/url-signer/pull/38, it might be good to keep the previous behavior to not break other dependent libraries.