### PR TITLE
Fixing "createFromWidowsPath" -> "createFromWindowsPath"

### DIFF
--- a/docs/schemes/1.0/schemes/file.md
+++ b/docs/schemes/1.0/schemes/file.md
@@ -23,7 +23,7 @@ In addition to the defined named constructors, because file path depends on the 
 
 use League\Uri;
 
-$uri = Uri\File::createFromWidowsPath('c:\windows\My Documents\my word.docx');
+$uri = Uri\File::createFromWindowsPath('c:\windows\My Documents\my word.docx');
 echo $uri; //returns 'file://localhost/c:My%20Documents/my%20word.docx'
 ~~~
 

--- a/docs/uri/6.0/rfc3986.md
+++ b/docs/uri/6.0/rfc3986.md
@@ -102,7 +102,7 @@ echo $uri; //returns 'data:image/png;charset=binary;base64,...'
 Returns a new URI object using the `file` scheme for a Windows file path.
 
 ~~~php
-$uri = Uri::createFromWidowsPath('c:\windows\My Documents\my word.docx');
+$uri = Uri::createFromWindowsPath('c:\windows\My Documents\my word.docx');
 echo $uri; //returns 'file://localhost/c:My%20Documents/my%20word.docx'
 ~~~
 


### PR DESCRIPTION
Hey @nyamsprod,

just fixing a typo on the documentation page: `createFromWidowsPath` -> `createFromWindowsPath`.

Cheers,
Peter