### PR TITLE
Remove requirement of json extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "league/uri-interfaces": "^2.4",
         "psr/http-message": "^1.0"
     },


### PR DESCRIPTION
Since PHP 8.0, `ext-json` is part of PHP core and cannot be disabled (see https://www.php.net/manual/en/json.installation.php).

I think it can be removed from `composer.json` require section.