### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/Uri.php
+++ b/Uri.php
@@ -444,7 +444,10 @@ final class Uri implements Conditionable, UriInterface, UriRenderer, UriInspecto
      */
     private function formatPort(?int $port = null): ?int
     {
-        $defaultPort = self::SCHEME_DEFAULT_PORT[$this->scheme] ?? null;
+        $defaultPort = null;
+        if ($this->scheme !== null && array_key_exists($this->scheme, self::SCHEME_DEFAULT_PORT)) {
+            $defaultPort = self::SCHEME_DEFAULT_PORT[$this->scheme];
+        };
 
         return match (true) {
             null === $port, $defaultPort === $port => null,
@@ -1104,7 +1107,7 @@ final class Uri implements Conditionable, UriInterface, UriRenderer, UriInspecto
     {
         try {
             if ('blob' !== $this->scheme) {
-                if (!isset(static::WHATWG_SPECIAL_SCHEMES[$this->scheme])) {
+                if ($this->scheme === null || !isset(static::WHATWG_SPECIAL_SCHEMES[$this->scheme])) {
                     return null;
                 }
 


### PR DESCRIPTION
This will fix the following deprecation:
```
Using null as an array offset is deprecated, use an empty string instead
Stack trace:
#0 vendor/league/uri/Uri.php(372): Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, 'Using null as a...', '/home/runner/wo...', 372)
#1 vendor/league/uri/Uri.php(227): League\Uri\Uri->formatPort(NULL)
#2 vendor/league/uri/Uri.php(391): League\Uri\Uri->__construct(NULL, NULL, Object(SensitiveParameterValue), NULL, NULL, 'variables.foo', NULL, NULL)
#3 src/Parser/StylesheetParser.php(1280): League\Uri\Uri::new('variables.foo')
```